### PR TITLE
Add Base.axes(schedule) and some tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,4 +18,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 title = "ParameterSchedulers.jl"
 
 [targets]
-test = ["InfiniteArrays", "Test"]
+test = ["Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,7 @@ Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
 InfiniteArrays = "4858937d-0d70-526a-a4dd-2d5cb5dd786c"
 
 [compat]
+InfiniteArrays = "0.10.4"
 Flux = "0.11.2, 0.12"
 julia = "1.5"
 

--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.2.1"
 
 [deps]
 Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
+InfiniteArrays = "4858937d-0d70-526a-a4dd-2d5cb5dd786c"
 
 [compat]
 Flux = "0.11.2, 0.12"
@@ -17,4 +18,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 title = "ParameterSchedulers.jl"
 
 [targets]
-test = ["Test"]
+test = ["InfiniteArrays", "Test"]

--- a/src/ParameterSchedulers.jl
+++ b/src/ParameterSchedulers.jl
@@ -2,6 +2,7 @@ module ParameterSchedulers
 
 using Base.Iterators
 using Flux
+using InfiniteArrays: OneToInf
 
 export Sequence, Loop,
        Step, Exp, Poly, Inv,

--- a/src/complex.jl
+++ b/src/complex.jl
@@ -109,6 +109,8 @@ Base.IteratorSize(::Type{<:Loop}) = Base.IsInfinite()
 
 Base.iterate(schedule::Loop, t = 1) = schedule(t), t + 1
 
+Base.axes(::Loop) = (OneToInf(),)
+
 """
     reverse(f, period)
 

--- a/src/cyclic.jl
+++ b/src/cyclic.jl
@@ -32,6 +32,8 @@ Base.IteratorSize(::Type{<:Triangle}) = Base.IsInfinite()
 
 Base.iterate(schedule::Triangle, t = 1) = schedule(t), t + 1
 
+Base.axes(::Triangle) = (OneToInf(),)
+
 """
     TriangleDecay2{T, S<:Integer}(range0, range1, period)
     TriangleDecay2(;λ0, λ1, period)
@@ -63,6 +65,8 @@ Base.eltype(::Type{<:TriangleDecay2{T}}) where T = T
 Base.IteratorSize(::Type{<:TriangleDecay2}) = Base.IsInfinite()
 
 Base.iterate(schedule::TriangleDecay2, t = 1) = schedule(t), t + 1
+
+Base.axes(::TriangleDecay2) = (OneToInf(),)
 
 """
     TriangleExp{T, S<:Integer}(range0, range1, period, decay)
@@ -101,6 +105,8 @@ Base.IteratorSize(::Type{<:TriangleExp}) = Base.IsInfinite()
 
 Base.iterate(schedule::TriangleExp, t = 1) = schedule(t), t + 1
 
+Base.axes(::TriangleExp) = (OneToInf(),)
+
 """
     Sin{T, S<:Integer}(range0, range1, period)
     Sin(;λ0, λ1, period)
@@ -129,6 +135,8 @@ Base.eltype(::Type{<:Sin{T}}) where T = T
 Base.IteratorSize(::Type{<:Sin}) = Base.IsInfinite()
 
 Base.iterate(schedule::Sin, t = 1) = schedule(t), t + 1
+
+Base.axes(::Sin) = (OneToInf(),)
 
 """
     SinDecay2{T, S<:Integer}(range0, range1, period)
@@ -160,6 +168,8 @@ Base.eltype(::Type{<:SinDecay2{T}}) where T = T
 Base.IteratorSize(::Type{<:SinDecay2}) = Base.IsInfinite()
 
 Base.iterate(schedule::SinDecay2, t = 1) = schedule(t), t + 1
+
+Base.axes(::SinDecay2) = (OneToInf(),)
 
 """
     SinExp{T, S<:Integer}(range0, range1, period, decay)
@@ -194,6 +204,8 @@ Base.IteratorSize(::Type{<:SinExp}) = Base.IsInfinite()
 
 Base.iterate(schedule::SinExp, t = 1) = schedule(t), t + 1
 
+Base.axes(::SinExp) = (OneToInf(),)
+
 """
     Cos{T, S<:Integer}(range0, range1, period)
     Cos(;λ0, λ1, period)
@@ -226,3 +238,5 @@ Base.eltype(::Type{<:Cos{T}}) where T = T
 Base.IteratorSize(::Type{<:Cos}) = Base.IsInfinite()
 
 Base.iterate(schedule::Cos, t = 1) = schedule(t), t + 1
+
+Base.axes(::Cos) = (OneToInf(),)

--- a/src/decay.jl
+++ b/src/decay.jl
@@ -45,6 +45,8 @@ function Base.iterate(schedule::Step, state = (1, 1, 1))
     return schedule.start * schedule.decay^(i - 1), (t + 1, i, t0)
 end
 
+Base.axes(::Step) = (OneToInf(),)
+
 
 """
     Exp{T}(start, decay)
@@ -72,6 +74,8 @@ Base.eltype(::Type{<:Exp{T}}) where T = T
 Base.IteratorSize(::Type{<:Exp}) = Base.IsInfinite()
 
 Base.iterate(schedule::Exp, t = 1) = schedule(t), t + 1
+
+Base.axes(::Exp) = (OneToInf(),)
 
 """
     Poly{T, S<:Integer}(start, degree, max_iter)
@@ -106,6 +110,8 @@ Base.length(schedule::Poly) = schedule.max_iter
 
 Base.iterate(schedule::Poly, t = 1) = schedule(t), t + 1
 
+Base.axes(schedule::Poly) = 1:length(schedule)
+
 
 """
     Inv{T, S<:Integer}(start, decay, degree)
@@ -135,3 +141,5 @@ Base.eltype(::Type{<:Inv{T}}) where T = T
 Base.IteratorSize(::Type{<:Inv}) = Base.IsInfinite()
 
 Base.iterate(schedule::Inv, t = 1) = schedule(t), t + 1
+
+Base.axes(::Inv) = (OneToInf(),)

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -25,7 +25,7 @@ end
     @test all(p == log(mod1(t, period)) for (t, p) in zip(1:100, s))
     @test Base.IteratorEltype(typeof(s)) == Base.IteratorEltype(typeof(log))
     @test Base.IteratorSize(typeof(s)) == Base.IsInfinite()
-    @test axes(s) == OneToInf()
+    @test axes(s) == (OneToInf(),)
 
     @testset "utilities" begin
         reverse_f = ParameterSchedulers.reverse(log, period)

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -25,6 +25,7 @@ end
     @test all(p == log(mod1(t, period)) for (t, p) in zip(1:100, s))
     @test Base.IteratorEltype(typeof(s)) == Base.IteratorEltype(typeof(log))
     @test Base.IteratorSize(typeof(s)) == Base.IsInfinite()
+    @test axes(s) == OneToInf()
 
     @testset "utilities" begin
         reverse_f = ParameterSchedulers.reverse(log, period)

--- a/test/cyclic.jl
+++ b/test/cyclic.jl
@@ -14,6 +14,7 @@ _cos(t, period) = (1 + cos(π * mod(t - 1, period) / period)) / 2
     @test Base.IteratorEltype(typeof(s)) == Base.HasEltype()
     @test eltype(s) == eltype(λ0)
     @test Base.IteratorSize(typeof(s)) == Base.IsInfinite()
+    @test axes(s) == (OneToInf(),)
 end
 
 @testset "TriangleDecay2" begin
@@ -27,6 +28,7 @@ end
     @test Base.IteratorEltype(typeof(s)) == Base.HasEltype()
     @test eltype(s) == eltype(λ0)
     @test Base.IteratorSize(typeof(s)) == Base.IsInfinite()
+    @test axes(s) == (OneToInf(),)
 end
 
 @testset "TriangleExp" begin
@@ -54,6 +56,7 @@ end
     @test Base.IteratorEltype(typeof(s)) == Base.HasEltype()
     @test eltype(s) == eltype(λ0)
     @test Base.IteratorSize(typeof(s)) == Base.IsInfinite()
+    @test axes(s) == (OneToInf(),)
 end
 
 @testset "SinDecay2" begin
@@ -67,6 +70,7 @@ end
     @test Base.IteratorEltype(typeof(s)) == Base.HasEltype()
     @test eltype(s) == eltype(λ0)
     @test Base.IteratorSize(typeof(s)) == Base.IsInfinite()
+    @test axes(s) == (OneToInf(),)
 end
 
 @testset "SinExp" begin
@@ -81,6 +85,7 @@ end
     @test Base.IteratorEltype(typeof(s)) == Base.HasEltype()
     @test eltype(s) == eltype(λ0)
     @test Base.IteratorSize(typeof(s)) == Base.IsInfinite()
+    @test axes(s) == (OneToInf(),)
 end
 
 @testset "Cos" begin
@@ -94,4 +99,5 @@ end
     @test Base.IteratorEltype(typeof(s)) == Base.HasEltype()
     @test eltype(s) == eltype(λ0)
     @test Base.IteratorSize(typeof(s)) == Base.IsInfinite()
+    @test axes(s) == (OneToInf(),)
 end

--- a/test/decay.jl
+++ b/test/decay.jl
@@ -18,6 +18,7 @@
     @test Base.IteratorEltype(typeof(s)) == Base.HasEltype()
     @test eltype(s) == eltype(λ)
     @test Base.IteratorSize(typeof(s)) == Base.IsInfinite()
+    @test axes(s) == (OneToInf(),)
 end
 
 @testset "Exp" begin
@@ -30,6 +31,7 @@ end
     @test Base.IteratorEltype(typeof(s)) == Base.HasEltype()
     @test eltype(s) == eltype(λ)
     @test Base.IteratorSize(typeof(s)) == Base.IsInfinite()
+    @test axes(s) == (OneToInf(),)
 end
 
 @testset "Poly" begin
@@ -45,6 +47,7 @@ end
     @test Base.IteratorSize(typeof(s)) == Base.HasLength()
     @test length(s) == max_iter
     @test_throws BoundsError s(max_iter + 1)
+    @test axes(s) == 1:length(s)
 end
 
 @testset "Inv" begin
@@ -58,4 +61,5 @@ end
     @test Base.IteratorEltype(typeof(s)) == Base.HasEltype()
     @test eltype(s) == eltype(λ)
     @test Base.IteratorSize(typeof(s)) == Base.IsInfinite()
+    @test axes(s) == (OneToInf(),)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
 using ParameterSchedulers
 using Test
 
-using InfiniteArrays: OneToInf()
+using InfiniteArrays: OneToInf
 
 @testset "Decay" begin
     include("decay.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,8 @@
 using ParameterSchedulers
 using Test
 
+using InfiniteArrays: OneToInf()
+
 @testset "Decay" begin
     include("decay.jl")
 end


### PR DESCRIPTION
This should fix #7 by defining `Base.axes` for schedules. In the case of infinite length schedules, `InfiniteArrays.OneToInf()` is used to define the axes.

Currently, this still doesn't completely fix #7, because `zip(schedule, 1:100)` has trouble promoting the shape of the overall `zip` iterator to be `(Base.OneTo(100),)`. I filed an issue [here](https://github.com/JuliaArrays/InfiniteArrays.jl/issues/67), but I'm not sure of the right way to handle this.