### PR TITLE
Add advance predicate to `Stateful`

### DIFF
--- a/src/complex.jl
+++ b/src/complex.jl
@@ -1,25 +1,30 @@
 """
     Stateful{T, S}
-    Stateful(schedule::T)
+    Stateful(schedule::T; advance = state -> true)
 
 Create a stateful iterator around `schedule`.
+Pass in a predicate, `advance(state)`, to conditionally control iteration.
 See also [`ParameterSchedulers.next!`](#) and [`ParameterSchedulers.reset!`](#).
 """
-mutable struct Stateful{T, S<:Integer}
+mutable struct Stateful{T, S<:Integer, R}
     schedule::T
     state::S
+    advance::R
 end
-Stateful(schedule) = Stateful(schedule, 1)
+Stateful(schedule; advance = state -> true) = Stateful(schedule, 1, advance)
 
 """
     next!(iter::Stateful)
 
-Advance `iter` by one iteration and return the next value.
+Advance `iter` by one iteration
+(if `iter.advance(state) == true`) and return the next value.
 See also [`ParameterSchedulers.Stateful`](#).
 """
 function next!(iter::Stateful)
     val = iter.schedule(iter.state)
-    iter.state += 1
+    if iter.advance(iter.state)
+        iter.state += 1
+    end
 
     return val
 end

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -40,4 +40,7 @@ end
     @test all(next!(stateful_s) == log(i) for i in 1:100)
     reset!(stateful_s)
     @test log(1) == next!(stateful_s)
+    stateful_s = Stateful(log; advance = s -> s == 1)
+    @test log(1) == next!(stateful_s)
+    @test log(1) == next!(stateful_s)
 end

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -42,5 +42,6 @@ end
     @test log(1) == next!(stateful_s)
     stateful_s = Stateful(log; advance = s -> s == 1)
     @test log(1) == next!(stateful_s)
-    @test log(1) == next!(stateful_s)
+    @test log(2) == next!(stateful_s)
+    @test log(2) == next!(stateful_s)
 end


### PR DESCRIPTION
Fixes #11 by adding an `advance` keyword to `Stateful`. This can be used in combination with [`Flux.plateau`](https://github.com/FluxML/Flux.jl/pull/1545) to create `ReduceLROnPlateau` (with the added benefit that our implementation can compose with any existing schedule and use alternate predicates than plateaus.