### PR TITLE
Add Interpolator schedule

### DIFF
--- a/docs/tutorials/optimizers.md
+++ b/docs/tutorials/optimizers.md
@@ -87,3 +87,5 @@ loss(x, y, m) = Flux.mse(m(x), y)
 cb = () -> @show(opt.optim.eta)
 Flux.@epochs nepochs Flux.train!((x, y) -> loss(x, y, m), params(m), data, opt, cb = cb)
 ```
+
+Finally, you might be interested in reading [Interpolating schedules](#) to see how to specify a schedule in terms of epochs but iterate it at the granularity of batches.

--- a/src/ParameterSchedulers.jl
+++ b/src/ParameterSchedulers.jl
@@ -4,15 +4,16 @@ using Base.Iterators
 using Flux
 using InfiniteArrays: OneToInf
 
-export Sequence, Loop,
-       Step, Exp, Poly, Inv,
-       Triangle, TriangleDecay2, TriangleExp,
+include("decay.jl")
+export Step, Exp, Poly, Inv
+
+include("cyclic.jl")
+export Triangle, TriangleDecay2, TriangleExp,
        Sin, SinDecay2, SinExp,
        Cos
 
-include("decay.jl")
-include("cyclic.jl")
 include("complex.jl")
+export Sequence, Loop, Interpolator
 
 # TODO
 # Remove this once Optimisers.jl has support

--- a/src/complex.jl
+++ b/src/complex.jl
@@ -137,6 +137,32 @@ Base.iterate(schedule::Loop, t = 1) = schedule(t), t + 1
 Base.axes(::Loop) = (OneToInf(),)
 
 """
+    Interpolator{T, S}
+    Interpolator(schedule, rate)
+
+A schedule whose output is `schedule(t / rate)` (i.e. it interpolates `schedule(t)`).
+
+This can be useful when your code iterates over real numbers at a fixed rate
+(e.g. in a fixed time step differential solver),
+but you want to use a schedule that iterates discretely over integers.
+
+It could also be used to specify `schedule` in units of epochs,
+while iterating it in units of mini-batches.
+"""
+struct Interpolator{T, S}
+    schedule::T
+    rate::S
+end
+
+(interpolator::Interpolator)(t) = interpolator.schedule(t / interpolator.rate)
+
+Base.eltype(::Type{<:Interpolator{T}}) where T = eltype(T)
+Base.IteratorEltype(::Type{<:Interpolator{T}}) where T = Base.IteratorEltype(T)
+Base.IteratorSize(::Type{<:Interpolator{T}}) where T = Base.IteratorSize(T)
+
+Base.iterate(interpolator::Interpolator, t = 1) = interpolator(t), t + 1
+
+"""
     reverse(f, period)
 
 Return a reverse function such that `reverse(f, period)(t) == f(period - t)`.

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -35,6 +35,19 @@ end
     end
 end
 
+@testset "Interpolator" begin
+    dt = 1e-3
+    s = Interpolator(sin, dt)
+    @test [s(t) for t in dt:dt:(100 * dt)] ≈ sin.(1:100)
+
+    values = [1, 2, 3]
+    epochs = [10, 10, 30]
+    nbatches = 5
+    s = Interpolator(Sequence([1, 2, 3], epochs), nbatches)
+    correct_seq = vcat([fill(v, nbatches * nepochs) for (v, nepochs) in zip(values, epochs)]...)
+    @test [s(t) for t in 1:(sum(epochs) * nbatches)] == correct_seq
+end
+
 @testset "Stateful" begin
     stateful_s = Stateful(log)
     @test all(next!(stateful_s) == log(i) for i in 1:100)


### PR DESCRIPTION
Add an `Interpolator` schedule that is useful when working with non-integer iteration or for swapping units between schedule specification and iteration.