### PR TITLE
Allow `Sequence` to accept generator expressions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         version:
           - '1'
-          - '1.5' # this is the oldest compat
+          - '1.6' # this is the oldest compat
           - 'nightly'
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ InfiniteArrays = "4858937d-0d70-526a-a4dd-2d5cb5dd786c"
 [compat]
 Flux = "0.11.2, 0.12"
 InfiniteArrays = "0.10.4, 0.11, 0.12"
-julia = "1.5"
+julia = "1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -32,7 +32,7 @@ If you are coming from PyTorch or Tensorflow, the following table should help yo
 
 ## Cosine annealing variants
 
-In addition to the plain cosine annealing w/ warm restarts schedule, we may want to decay the peak learning rate or increase the period. Both can be done using [`ComposedSchedule`](#).
+In addition to the plain cosine annealing w/ warm restarts schedule, we may want to decay the peak learning rate or increase the period. Both can be done using [`ComposedSchedule`](#) or [`Sequence`](#).
 
 Let's start with the simpler task: decaying the learning rate.
 ```julia
@@ -41,7 +41,15 @@ s = ComposedSchedule(CosAnneal(range, offset, period),
                      (Step(range, m_mul, period), offset, period))
 ```
 
+To increase the period by a fixed multiple, we should think of each period of the schedule as an individual schedule concatenated together. This is exactly what [`Sequence`](#) is except that there is no limit to the number of periods that we concatenate together. Fortunately, `Sequence` accepts [`Base.Generators`](https://docs.julialang.org/en/v1.7/manual/arrays/#Generator-Expressions). When combined with [InfiniteArrays.jl](https://github.com/JuliaArrays/InfiniteArrays.jl), we can create an infinite sequence of individual schedules.
+```julia
+using InfiniteArrays: OneToInf
 
+# increase period by factor t_mul
+e = Exp(period, t_mul)
+s = Sequence(CosAnneal(range, offset, e(t)) for t in OneToInf(),
+             e(t) for t in OneToInf())
+```
 
 ## `ReduceLROnPlateau` style schedules
 

--- a/docs/tutorials/complex-schedules.md
+++ b/docs/tutorials/complex-schedules.md
@@ -51,6 +51,15 @@ t = 1:20 |> collect
 lineplot(t, s.(t); border = :none)
 ```
 
+`Sequence` also accepts [`Base.Generators`](https://docs.julialang.org/en/v1.7/manual/arrays/#Generator-Expressions).
+{cell=complex-schedules}
+```julia
+s = Sequence(2 / t for t in 1:10)
+t = 1:50 |> collect
+lineplot(t, s.(t); border = :none)
+```
+We can also pass a separate generator for `schedules` and `step_sizes`. When only a single generator is passed, `step_sizes` is the iterator that the generator is based on.
+
 ## Interpolating schedules
 
 Sometimes, we want to specify a schedule in different units than our iteration state. Below, we'll see two common examples where this might be the case, and how [`Interpolator`](#) can make our lives a bit easier.

--- a/src/cyclic.jl
+++ b/src/cyclic.jl
@@ -23,7 +23,7 @@ struct Triangle{T, S<:Integer} <: AbstractSchedule{false}
     offset::T
     period::S
 end
-function Triangle(range::T, offset::T, period::S) where {T, S<:Integer}
+function Triangle(range::T, offset::T, period::S) where {T, S}
     @warn """Triangle(range0, range1, period) is now Triangle(range, offset, period).
              To specify by endpoints, use the keyword argument form.
              This message will be removed in the next version.""" _id=(:tri) maxlog=1
@@ -117,7 +117,7 @@ struct Sin{T, S<:Integer} <: AbstractSchedule{false}
     offset::T
     period::S
 end
-function Sin(range::T, offset::T, period::S) where {T, S<:Integer}
+function Sin(range::T, offset::T, period::S) where {T, S}
     @warn """Sin(range0, range1, period) is now Sin(range, offset, period).
              To specify by endpoints, use the keyword argument form.
              This message will be removed in the next version.""" _id=(:sine) maxlog=1

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -15,6 +15,17 @@
     @test s(i) == ((i > step_sizes[1]) ? params[2] : params[1])
     @test all(p == ((t > step_sizes[1]) ? params[2] : params[1])
               for (t, p) in zip(1:50, s))
+
+    @testset "Infinite Sequences" begin
+        s = Sequence(Exp(1.0, 0.5 * step) for step in OneToInf())
+        t0 = 1
+        for step in 1:4
+            e = Exp(1.0, 0.5 * step)
+            ts = t0:(t0 - 1 + step)
+            @test s.(ts) ≈ e.(1:step)
+            t0 += step
+        end
+    end
 end
 
 @testset "Loop" begin


### PR DESCRIPTION
`Sequence` can now accept generator expressions like:
```julia
s = Sequence(2 * t for t in 1:10)
```
This is equivalent to
```julia
schedules = [2 * t for t in 1:10]
s = Sequence(schedules, 1:10)
```

You can also pass to different generators:
```julia
s = Sequence(2 * t for t in 1:10, 100 * t for t in 1:10)
```

Note that infinite generators like those in InfiniteArrays.jl are supported too. In general, the schedules and step sizes can both be infinite iterators.