### PR TITLE
Add `OffsetStart`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ParameterSchedulers"
 uuid = "d7d3b36b-41b8-4d0d-a2bf-768c6151755e"
 authors = ["Kyle Daruwalla"]
-version = "0.3.0"
+version = "0.3.1"
 
 [deps]
 Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"

--- a/docs/tutorials/complex-schedules.md
+++ b/docs/tutorials/complex-schedules.md
@@ -60,6 +60,8 @@ lineplot(t, s.(t); border = :none)
 ```
 We can also pass a separate generator for `schedules` and `step_sizes`. When only a single generator is passed, `step_sizes` is the iterator that the generator is based on.
 
+Lastly, the schedules in a `Sequence` can use [`Shifted`](#) to start at an iteration other than `t = 1`.
+
 ## Interpolating schedules
 
 Sometimes, we want to specify a schedule in different units than our iteration state. Below, we'll see two common examples where this might be the case, and how [`Interpolator`](#) can make our lives a bit easier.

--- a/docs/tutorials/warmup-schedules.md
+++ b/docs/tutorials/warmup-schedules.md
@@ -1,0 +1,66 @@
+# Warm-up Schedules
+
+A popular technique for scheduling learning rates is "warming-up" the optimizer by ramping the learning rate up from zero to the "true" initial learning rate, then starting the "real" schedule. This is easily implementable with ParameterSchedulers.jl using [`Sequence`](#).
+
+## Linear ramp
+
+Suppose we want to increase our learning rate using a linear ramp function. We can achieve this by running a [`Triangle`](#) schedule for a half-period.
+
+{cell=ramp}
+```julia
+using ParameterSchedulers
+using UnicodePlots
+
+min_lr = 1e-6 # don't actually start with lr = 0
+initial_lr = 1e-2
+warmup = 20 # warmup for 20 epochs
+
+ramp = Triangle(λ0 = min_lr, λ1 = initial_lr, period = 2 * warmup)
+
+t = 1:warmup |> collect
+lineplot(t, ramp.(t); border = :none)
+```
+
+Of course, if we run the `Triangle` for more than `warmup` iterations, it will be periodic. So, we want to make sure to start our "real" schedule immediately after half a period.
+
+{cell=ramp}
+```julia
+total_iters = 100
+
+# let's wrap it all up in a convenience constructor
+WarmupLinear(startlr, initlr, warmup, total_iters, schedule) =
+    Sequence(Triangle(λ0 = startlr, λ1 = initlr, period = 2 * warmup) => warmup,
+             schedule => total_iters)
+
+s = WarmupLinear(min_lr, initial_lr, warmup, total_iters, Exp(initial_lr, 0.8))
+t = 1:total_iters |> collect
+lineplot(t, s.(t); border = :none)
+```
+
+## Sine ramp
+
+Another common ramp function is a half period of a sine wave. We can use [`Sin`](#) and the same technique as the previous section.
+
+{cell=ramp}
+```julia
+WarmupSin(startlr, initlr, warmup, total_iters, schedule) =
+    Sequence(Sin(λ0 = startlr, λ1 = initlr, period = 2 * warmup) => warmup,
+             schedule => total_iters)
+
+s = WarmupSin(min_lr, initial_lr, warmup, total_iters, Exp(initial_lr, 0.8))
+t = 1:total_iters |> collect
+lineplot(t, s.(t); border = :none)
+```
+
+## Using `Shifted` to start the "real" schedule
+
+Sometimes, the "real" schedule doesn't start at the `initial_lr` like `Exp`. Suppose we want a sine warmup followed by a `Triangle` schedule. `Triangle` starts at `min(λ0, λ1)`, so to get this correct, we want to start the `Triangle` half-way through its first period. We can use [`Shifted`](#) to do this.
+
+{cell=ramp}
+```julia
+# shift the Triangle by half a period + 1 to start at the peak
+tri = Shifted(Triangle(λ0 = min_lr, λ1 = initial_lr, period = 10), 6)
+s = WarmupSin(min_lr, initial_lr, warmup, total_iters, tri)
+t = 1:50 |> collect
+lineplot(t, s.(t); border = :none)
+```

--- a/src/ParameterSchedulers.jl
+++ b/src/ParameterSchedulers.jl
@@ -15,7 +15,7 @@ export Triangle, TriangleDecay2, TriangleExp,
        CosAnneal
 
 include("complex.jl")
-export Sequence, Loop, Interpolator, OffsetStart, ComposedSchedule
+export Sequence, Loop, Interpolator, Shifted, ComposedSchedule
 
 include("utils.jl")
 

--- a/src/ParameterSchedulers.jl
+++ b/src/ParameterSchedulers.jl
@@ -15,7 +15,7 @@ export Triangle, TriangleDecay2, TriangleExp,
        CosAnneal
 
 include("complex.jl")
-export Sequence, Loop, Interpolator, ComposedSchedule
+export Sequence, Loop, Interpolator, OffsetStart, ComposedSchedule
 
 include("utils.jl")
 

--- a/src/complex.jl
+++ b/src/complex.jl
@@ -170,6 +170,32 @@ Base.IteratorSize(::Type{<:Interpolator{T}}) where T = Base.IteratorSize(T)
 (interpolator::Interpolator)(t) =
     interpolator.schedule(interpolator.ceil_fn(t / interpolator.rate))
 
+"""
+    OffsetStart(schedule, offset)
+
+`schedule` that starts at `t == offset`
+(i.e. calling an `OffsetStart` with `t = 1` is equivalent to calling
+`schedule` with `t = offset`)
+"""
+struct OffsetStart{T} <: AbstractSchedule{T}
+    schedule::T
+    offset::Int
+end
+
+Base.eltype(::Type{<:OffsetStart{T}}) where T = eltype(T)
+Base.IteratorEltype(::Type{<:OffsetStart{T}}) where T = Base.IteratorEltype(T)
+
+(offset_schedule::OffsetStart)(t) = offset_schedule.schedule(t - 1 + offset_schedule.offset)
+
+"""
+    ComposedSchedule([(s, ps) -> T(ps...), ]schedule::T, parameters)
+
+A `schedule` whose fields are given by `parameters.(t)` at iteration `t`.
+
+At each step `t`, this gets a new set of parameters with `parameters.(t)`,
+then creates a new `schedule` given the first (optional) argument.
+The new `schedule(t)` is the returned value.
+"""
 struct ComposedSchedule{T, S, F} <: AbstractSchedule{T}
     compose_fn::F
     schedule::T

--- a/src/complex.jl
+++ b/src/complex.jl
@@ -96,11 +96,12 @@ function (schedule::Sequence)(t)
         acc += step
         return t > acc
     end |> collect
-    i, toffset = isempty(itr) ? (0, 0) : (last(itr)[1], acc - last(itr)[2] - 1)
+    i = isempty(itr) ? 0 : last(itr)[1]
+    toffset = isempty(itr) ? 0 :
+        acc - something(_peel(Iterators.drop(schedule.step_sizes, i)), (0,))[1]
     sitr = _peel(Iterators.drop(schedule.schedules, i))
     s = isnothing(sitr) ? schedule.schedules[end] : first(sitr)
 
-    # @show s, t, toffset, acc
     return s(t - toffset)
 end
 

--- a/src/complex.jl
+++ b/src/complex.jl
@@ -171,21 +171,21 @@ Base.IteratorSize(::Type{<:Interpolator{T}}) where T = Base.IteratorSize(T)
     interpolator.schedule(interpolator.ceil_fn(t / interpolator.rate))
 
 """
-    OffsetStart(schedule, offset)
+    Shifted(schedule, offset)
 
-`schedule` that starts at `t == offset`
-(i.e. calling an `OffsetStart` with `t = 1` is equivalent to calling
+A `schedule` who's starting iteration is shifted to `offset`.
+(i.e. calling an `Shifted` with `t = 1` is equivalent to calling
 `schedule` with `t = offset`)
 """
-struct OffsetStart{T} <: AbstractSchedule{T}
+struct Shifted{T} <: AbstractSchedule{T}
     schedule::T
     offset::Int
 end
 
-Base.eltype(::Type{<:OffsetStart{T}}) where T = eltype(T)
-Base.IteratorEltype(::Type{<:OffsetStart{T}}) where T = Base.IteratorEltype(T)
+Base.eltype(::Type{<:Shifted{T}}) where T = eltype(T)
+Base.IteratorEltype(::Type{<:Shifted{T}}) where T = Base.IteratorEltype(T)
 
-(offset_schedule::OffsetStart)(t) = offset_schedule.schedule(t - 1 + offset_schedule.offset)
+(offset_schedule::Shifted)(t) = offset_schedule.schedule(t - 1 + offset_schedule.offset)
 
 """
     ComposedSchedule([(s, ps) -> T(ps...), ]schedule::T, parameters)

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -59,6 +59,13 @@ end
     @test [s(t) for t in 1:(sum(epochs) * nbatches)] == correct_seq
 end
 
+@testset "OffsetStart" begin
+    s = Triangle(λ0 = 0, λ1 = 1, period = 10)
+    soffset = OffsetStart(s, 5)
+
+    @test [soffset(t) for t in 1:50] == [s(t) for t in 5:54]
+end
+
 @testset "Stateful" begin
     stateful_s = Stateful(log)
     @test all(next!(stateful_s) == log(i) for i in 1:100)

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -59,9 +59,9 @@ end
     @test [s(t) for t in 1:(sum(epochs) * nbatches)] == correct_seq
 end
 
-@testset "OffsetStart" begin
+@testset "Shifted" begin
     s = Triangle(λ0 = 0, λ1 = 1, period = 10)
-    soffset = OffsetStart(s, 5)
+    soffset = Shifted(s, 5)
 
     @test [soffset(t) for t in 1:50] == [s(t) for t in 5:54]
 end

--- a/toc.md
+++ b/toc.md
@@ -8,6 +8,7 @@
 * [Basic schedules](docs/tutorials/basic-schedules.md)
 * [Optimizers](docs/tutorials/optimizers.md)
 * [Complex schedules](docs/tutorials/complex-schedules.md)
+* [Warmup schedules](docs/tutorials/warmup-schedules.md)
 
 [Interface](docs/interfaces/generic.md)
 


### PR DESCRIPTION
Adds `OffsetStart` which allows starting a schedule after a fixed offset. For example, `OffsetStart(Triangle(2, 10), 5)` will start after a half period of 5.