### PR TITLE
Update `Scheduler` for Flux v0.13 and add tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ParameterSchedulers"
 uuid = "d7d3b36b-41b8-4d0d-a2bf-768c6151755e"
 authors = ["Kyle Daruwalla"]
-version = "0.3.2"
+version = "0.3.3"
 
 [deps]
 Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"

--- a/src/ParameterSchedulers.jl
+++ b/src/ParameterSchedulers.jl
@@ -55,7 +55,7 @@ julia> opt = Scheduler(s, Momentum(); update_func = (o, s) -> o.rho = s)
 Scheduler(CosAnneal{Float64,Int64}(0.1, 0.8, 10), Momentum(0.01, 0.9, IdDict{Any,Any}()))
 ```
 """
-mutable struct Scheduler{T, O, F}
+mutable struct Scheduler{T, O, F} <: Flux.Optimise.AbstractOptimiser
     state::IdDict{Any, Int}
     schedule::T
     optim::O


### PR DESCRIPTION
Fixes #30 by sub-typing `AbstractOptimiser`. Also adds tests for `Scheduler` so that #29 doesn't happen again.