### PR TITLE
Fix bug when `Sequence` is iterated passed step sizes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ParameterSchedulers"
 uuid = "d7d3b36b-41b8-4d0d-a2bf-768c6151755e"
 authors = ["Kyle Daruwalla"]
-version = "0.3.3"
+version = "0.3.4"
 
 [deps]
 Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"

--- a/src/complex.jl
+++ b/src/complex.jl
@@ -98,7 +98,7 @@ function (schedule::Sequence)(t)
     end |> collect
     i = isempty(itr) ? 0 : last(itr)[1]
     toffset = isempty(itr) ? 0 :
-        acc - something(_peel(Iterators.drop(schedule.step_sizes, i)), (0,))[1]
+        acc - something(_peel(Iterators.drop(schedule.step_sizes, i)), (last(schedule.step_sizes),))[1]
     sitr = _peel(Iterators.drop(schedule.schedules, i))
     s = isnothing(sitr) ? schedule.schedules[end] : first(sitr)
 

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -16,6 +16,13 @@
     @test all(p == ((t > step_sizes[1]) ? params[2] : params[1])
               for (t, p) in zip(1:50, s))
 
+    # test iterating past end of sequence
+    s = Sequence(1 => 1, Step(0.1, 0.5, 10) => 50)
+    @test s(1) == 1
+    @test s(2) == 0.1
+    @test s(42) == 0.00625
+    @test s(52) == 0.003125
+
     @testset "Infinite Sequences" begin
         s = Sequence(Exp(1.0, 0.5 * step) for step in OneToInf())
         t0 = 1


### PR DESCRIPTION
This fixes a bug where a `Sequence` is iterated for too long. The expected behavior is that the last schedule in the sequence continues to iterate forever.

```julia
julia> s = Sequence(1 => 1, Step(0.1, 0.5, 10) => 50)
Sequence{Tuple{ParameterSchedulers.Constant{Int64}, Step{Float64, Base.Iterators.Repeated{Int64}}}, Tuple{Int64, Int64}}((ParameterSchedulers.Constant{Int64}(1), Step{Float64, Base.Iterators.Repeated{Int64}}(0.1, 0.5, Base.Iterators.Repeated{Int64}(10))), (1, 50))

julia> s(1)
1

julia> s(2)
0.1

julia> s(42)
0.00625

julia> s(52)
0.1
```

The last value here should be 0.003125.