### PR TITLE
moved Scheduler to extension

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,8 +4,14 @@ authors = ["Kyle Daruwalla"]
 version = "0.3.5"
 
 [deps]
-Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
 InfiniteArrays = "4858937d-0d70-526a-a4dd-2d5cb5dd786c"
+PackageExtensionCompat = "65ce6f38-6b18-4e1d-a461-8949797d7930"
+
+[weakdeps]
+Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
+
+[extensions]
+ParameterSchedulersFluxExt = "Flux"
 
 [compat]
 Flux = "0.11.2, 0.12, 0.13"
@@ -13,12 +19,13 @@ InfiniteArrays = "0.10.4, 0.11, 0.12"
 julia = "1.6"
 
 [extras]
+Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [publish]
-title = "ParameterSchedulers.jl"
-theme = "_flux-theme"
 ignore = ["^(gh-pages|juliamnt|julia.dmg)$"]
+theme = "_flux-theme"
+title = "ParameterSchedulers.jl"
 
 [targets]
-test = ["Test"]
+test = ["Test", "Flux"]

--- a/ext/ParameterSchedulersFluxExt.jl
+++ b/ext/ParameterSchedulersFluxExt.jl
@@ -1,0 +1,72 @@
+module ParameterSchedulersFluxExt
+
+using ParameterSchedulers, Flux
+
+mutable struct Scheduler{T, O, F} <: Flux.Optimise.AbstractOptimiser
+    state::IdDict{Any, Int}
+    schedule::T
+    optim::O
+    update_func::F
+end
+
+"""
+    Scheduler{T, O, F}(schedule::AbstractSchedule, opt, update_func)
+    Scheduler(schedule, opt; update_func = (o, s) -> (o.eta = s))
+
+Wrap a `schedule` and `opt` together with a `Scheduler`.
+The `schedule` is iterated on every call to
+[`Flux.apply!`](https://github.com/FluxML/Flux.jl/blob/master/src/optimise/optimisers.jl).
+The `Scheduler` can be used anywhere a Flux optimizer is used.
+
+By default, the learning rate (i.e. `opt.eta`) is scheduled.
+Set `update_func = (opt, schedule_val) -> ...` to schedule an alternate field.
+If `opt` does not have a field `eta`, then there is no default behavior
+(you must manually set `update_func`).
+
+# Arguments
+- `schedule`: the schedule to use
+- `opt`: a Flux optimizer
+- `update_func`: a mutating function of with inputs `(optim, param)`
+                 that mutates `optim`'s fields based on the current `param` value
+
+# Examples
+```julia
+# cosine annealing schedule for Descent
+julia> s = CosAnneal(λ0 = 0.1, λ1 = 0.8, period = 10);
+
+julia> opt = Scheduler(s, Descent())
+Scheduler(CosAnneal{Float64,Int64}(0.1, 0.8, 10), Descent(0.1))
+
+# schedule the momentum term of Momentum
+julia> opt = Scheduler(s, Momentum(); update_func = (o, s) -> o.rho = s)
+Scheduler(CosAnneal{Float64,Int64}(0.1, 0.8, 10), Momentum(0.01, 0.9, IdDict{Any,Any}()))
+```
+"""
+ParameterSchedulers.Scheduler(schedule, opt, update_func) =
+    Scheduler(IdDict{Any, Int}(), schedule, opt, update_func)
+
+Base.show(io::IO, s::Scheduler) =
+    print(io, "Scheduler(", s.schedule, ", ", s.optim, ")")
+
+function Flux.Optimise.apply!(opt::Scheduler, x, Δ)
+    # get iteration
+    t = get!(opt.state, x, 1)
+    opt.state[x] = t + 1
+
+    # set param
+    opt.update_func(opt.optim, opt.schedule(t))
+
+    # do normal apply
+    return Flux.Optimise.apply!(opt.optim, x, Δ)
+end
+
+for Opt in (Descent, Momentum, Nesterov, RMSProp,
+            Adam, RAdam, AdaMax, OAdam, AdaGrad,
+            AdaDelta, AMSGrad, NAdam, AdaBelief)
+    @eval begin
+        ParameterSchedulers.Scheduler(schedule, opt::$Opt; update_func = (o, s) -> (o.eta = s)) =
+            ParameterSchedulers.Scheduler(schedule, opt, update_func)
+    end
+end
+
+end

--- a/src/ParameterSchedulers.jl
+++ b/src/ParameterSchedulers.jl
@@ -1,7 +1,6 @@
 module ParameterSchedulers
 
 using Base.Iterators
-using Flux
 using InfiniteArrays: OneToInf
 
 include("interface.jl")
@@ -19,73 +18,13 @@ export Sequence, Loop, Interpolator, Shifted, ComposedSchedule
 
 include("utils.jl")
 
-# TODO
-# Remove this once Optimisers.jl has support
-# for schedules + optimizers
-"""
-    Scheduler{T, O, F}(schedule::AbstractSchedule, opt, update_func)
-    Scheduler(schedule, opt; update_func = (o, s) -> (o.eta = s))
-
-Wrap a `schedule` and `opt` together with a `Scheduler`.
-The `schedule` is iterated on every call to
-[`Flux.apply!`](https://github.com/FluxML/Flux.jl/blob/master/src/optimise/optimisers.jl).
-The `Scheduler` can be used anywhere a Flux optimizer is used.
-
-By default, the learning rate (i.e. `opt.eta`) is scheduled.
-Set `update_func = (opt, schedule_val) -> ...` to schedule an alternate field.
-If `opt` does not have a field `eta`, then there is no default behavior
-(you must manually set `update_func`).
-
-# Arguments
-- `schedule`: the schedule to use
-- `opt`: a Flux optimizer
-- `update_func`: a mutating function of with inputs `(optim, param)`
-                 that mutates `optim`'s fields based on the current `param` value
-
-# Examples
-```julia
-# cosine annealing schedule for Descent
-julia> s = CosAnneal(λ0 = 0.1, λ1 = 0.8, period = 10);
-
-julia> opt = Scheduler(s, Descent())
-Scheduler(CosAnneal{Float64,Int64}(0.1, 0.8, 10), Descent(0.1))
-
-# schedule the momentum term of Momentum
-julia> opt = Scheduler(s, Momentum(); update_func = (o, s) -> o.rho = s)
-Scheduler(CosAnneal{Float64,Int64}(0.1, 0.8, 10), Momentum(0.01, 0.9, IdDict{Any,Any}()))
-```
-"""
-mutable struct Scheduler{T, O, F} <: Flux.Optimise.AbstractOptimiser
-    state::IdDict{Any, Int}
-    schedule::T
-    optim::O
-    update_func::F
-end
-Scheduler(schedule, opt, update_func) =
-    Scheduler(IdDict{Any, Int}(), schedule, opt, update_func)
-
-Base.show(io::IO, s::Scheduler) =
-    print(io, "Scheduler(", s.schedule, ", ", s.optim, ")")
-
-function Flux.Optimise.apply!(opt::Scheduler, x, Δ)
-    # get iteration
-    t = get!(opt.state, x, 1)
-    opt.state[x] = t + 1
-
-    # set param
-    opt.update_func(opt.optim, opt.schedule(t))
-
-    # do normal apply
-    return Flux.Optimise.apply!(opt.optim, x, Δ)
+using PackageExtensionCompat
+function __init__()
+    @require_extensions
 end
 
-for Opt in (Descent, Momentum, Nesterov, RMSProp,
-            Adam, RAdam, AdaMax, OAdam, AdaGrad,
-            AdaDelta, AMSGrad, NAdam, AdaBelief)
-    @eval begin
-        Scheduler(schedule, opt::$Opt; update_func = (o, s) -> (o.eta = s)) =
-            Scheduler(schedule, opt, update_func)
-    end
-end
+# Extension functions
+function Scheduler end
+export Scheduler
 
 end


### PR DESCRIPTION
Addressing #46. I've moved the Scheduler code to an extension that is loaded only when Flux is also loaded. This is useful for when using a parameter scheduler but not necessarily using Flux (e.g. Lux). I've looked at [Lux.jl](https://github.com/LuxDL/Lux.jl/blob/main/src/Lux.jl) and their extensions to see how things are done. Specifically, I added [PackageExtensionCompat](https://github.com/cjdoris/PackageExtensionCompat.jl) as a depenency to ensure the extension is loaded correctly for Julia versions < 1.9 and added a dummy function definition for Scheduler. 

I tried to instead add a dummy struct definition for Scheduler but couldn't seem to do so without getting errors. That's why I moved the docstring to the first function definition of Scheduler in the extension module, instead of the struct definition, as otherwise the docstring would not be loaded/recognized. 

As written, this should not be a breaking change.
