### PR TITLE
Treat Flux dependency as an Extension 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1'
-          - '1.6' # this is the oldest compat
+          - '1.9' # this is the oldest compat
           - 'nightly'
         os:
           - ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /Manifest.toml
 /docs/build/
 /docs/Manifest.toml
+/test/Manifest.toml
 _flux-theme/

--- a/Project.toml
+++ b/Project.toml
@@ -1,19 +1,25 @@
 name = "ParameterSchedulers"
 uuid = "d7d3b36b-41b8-4d0d-a2bf-768c6151755e"
 authors = ["Kyle Daruwalla"]
-version = "0.3.6"
+version = "0.3.7"
 
 [deps]
-Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
 InfiniteArrays = "4858937d-0d70-526a-a4dd-2d5cb5dd786c"
+
+[weakdeps]
+Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
+
+[extensions]
+ParameterSchedulersFluxExt = "Flux"
 
 [compat]
 Flux = "0.11.2, 0.12, 0.13, 0.14"
 InfiniteArrays = "0.10.4, 0.11, 0.12, 0.13"
-julia = "1.6"
+julia = "1.9"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
 
 [publish]
 ignore = ["^(gh-pages|juliamnt|julia.dmg)$"]

--- a/ext/ParameterSchedulersFluxExt.jl
+++ b/ext/ParameterSchedulersFluxExt.jl
@@ -1,0 +1,71 @@
+module ParameterSchedulersFluxExt 
+
+using ParameterSchedulers, Flux 
+
+"""
+    Scheduler{T, O, F}(schedule::AbstractSchedule, opt, update_func)
+    Scheduler(schedule, opt; update_func = (o, s) -> (o.eta = s))
+
+Wrap a `schedule` and `opt` together with a `Scheduler`.
+The `schedule` is iterated on every call to
+[`Flux.apply!`](https://github.com/FluxML/Flux.jl/blob/master/src/optimise/optimisers.jl).
+The `Scheduler` can be used anywhere a Flux optimizer is used.
+
+By default, the learning rate (i.e. `opt.eta`) is scheduled.
+Set `update_func = (opt, schedule_val) -> ...` to schedule an alternate field.
+If `opt` does not have a field `eta`, then there is no default behavior
+(you must manually set `update_func`).
+
+# Arguments
+- `schedule`: the schedule to use
+- `opt`: a Flux optimizer
+- `update_func`: a mutating function of with inputs `(optim, param)`
+                 that mutates `optim`'s fields based on the current `param` value
+
+# Examples
+```julia
+# cosine annealing schedule for Descent
+julia> s = CosAnneal(λ0 = 0.1, λ1 = 0.8, period = 10);
+
+julia> opt = Scheduler(s, Descent())
+Scheduler(CosAnneal{Float64,Int64}(0.1, 0.8, 10), Descent(0.1))
+
+# schedule the momentum term of Momentum
+julia> opt = Scheduler(s, Momentum(); update_func = (o, s) -> o.rho = s)
+Scheduler(CosAnneal{Float64,Int64}(0.1, 0.8, 10), Momentum(0.01, 0.9, IdDict{Any,Any}()))
+```
+"""
+mutable struct Scheduler{T, O, F} <: Flux.Optimise.AbstractOptimiser
+    state::IdDict{Any, Int}
+    schedule::T
+    optim::O
+    update_func::F
+end
+Scheduler(schedule, opt, update_func) =
+    Scheduler(IdDict{Any, Int}(), schedule, opt, update_func)
+
+Base.show(io::IO, s::Scheduler) =
+    print(io, "Scheduler(", s.schedule, ", ", s.optim, ")")
+
+function Flux.Optimise.apply!(opt::Scheduler, x, Δ)
+    # get iteration
+    t = get!(opt.state, x, 1)
+    opt.state[x] = t + 1
+
+    # set param
+    opt.update_func(opt.optim, opt.schedule(t))
+
+    # do normal apply
+    return Flux.Optimise.apply!(opt.optim, x, Δ)
+end
+
+for Opt in (Descent, Momentum, Nesterov, RMSProp,
+            Adam, RAdam, AdaMax, OAdam, AdaGrad,
+            AdaDelta, AMSGrad, NAdam, AdaBelief)
+    @eval begin
+        Scheduler(schedule, opt::$Opt; update_func = (o, s) -> (o.eta = s)) =
+            Scheduler(schedule, opt, update_func)
+    end
+end
+
+end 

--- a/src/ParameterSchedulers.jl
+++ b/src/ParameterSchedulers.jl
@@ -18,4 +18,10 @@ export Sequence, Loop, Interpolator, Shifted, ComposedSchedule
 
 include("utils.jl")
 
+ext = Base.get_extension(@__MODULE__, :ParameterSchedulersFluxExt)
+if !isnothing(ext)
+    Scheduler = ext.Scheduler
+    export Scheduler
+end
+
 end

--- a/src/ParameterSchedulers.jl
+++ b/src/ParameterSchedulers.jl
@@ -1,7 +1,6 @@
 module ParameterSchedulers
 
 using Base.Iterators
-using Flux
 using InfiniteArrays: OneToInf
 
 include("interface.jl")
@@ -18,74 +17,5 @@ include("complex.jl")
 export Sequence, Loop, Interpolator, Shifted, ComposedSchedule
 
 include("utils.jl")
-
-# TODO
-# Remove this once Optimisers.jl has support
-# for schedules + optimizers
-"""
-    Scheduler{T, O, F}(schedule::AbstractSchedule, opt, update_func)
-    Scheduler(schedule, opt; update_func = (o, s) -> (o.eta = s))
-
-Wrap a `schedule` and `opt` together with a `Scheduler`.
-The `schedule` is iterated on every call to
-[`Flux.apply!`](https://github.com/FluxML/Flux.jl/blob/master/src/optimise/optimisers.jl).
-The `Scheduler` can be used anywhere a Flux optimizer is used.
-
-By default, the learning rate (i.e. `opt.eta`) is scheduled.
-Set `update_func = (opt, schedule_val) -> ...` to schedule an alternate field.
-If `opt` does not have a field `eta`, then there is no default behavior
-(you must manually set `update_func`).
-
-# Arguments
-- `schedule`: the schedule to use
-- `opt`: a Flux optimizer
-- `update_func`: a mutating function of with inputs `(optim, param)`
-                 that mutates `optim`'s fields based on the current `param` value
-
-# Examples
-```julia
-# cosine annealing schedule for Descent
-julia> s = CosAnneal(λ0 = 0.1, λ1 = 0.8, period = 10);
-
-julia> opt = Scheduler(s, Descent())
-Scheduler(CosAnneal{Float64,Int64}(0.1, 0.8, 10), Descent(0.1))
-
-# schedule the momentum term of Momentum
-julia> opt = Scheduler(s, Momentum(); update_func = (o, s) -> o.rho = s)
-Scheduler(CosAnneal{Float64,Int64}(0.1, 0.8, 10), Momentum(0.01, 0.9, IdDict{Any,Any}()))
-```
-"""
-mutable struct Scheduler{T, O, F} <: Flux.Optimise.AbstractOptimiser
-    state::IdDict{Any, Int}
-    schedule::T
-    optim::O
-    update_func::F
-end
-Scheduler(schedule, opt, update_func) =
-    Scheduler(IdDict{Any, Int}(), schedule, opt, update_func)
-
-Base.show(io::IO, s::Scheduler) =
-    print(io, "Scheduler(", s.schedule, ", ", s.optim, ")")
-
-function Flux.Optimise.apply!(opt::Scheduler, x, Δ)
-    # get iteration
-    t = get!(opt.state, x, 1)
-    opt.state[x] = t + 1
-
-    # set param
-    opt.update_func(opt.optim, opt.schedule(t))
-
-    # do normal apply
-    return Flux.Optimise.apply!(opt.optim, x, Δ)
-end
-
-for Opt in (Descent, Momentum, Nesterov, RMSProp,
-            Adam, RAdam, AdaMax, OAdam, AdaGrad,
-            AdaDelta, AMSGrad, NAdam, AdaBelief)
-    @eval begin
-        Scheduler(schedule, opt::$Opt; update_func = (o, s) -> (o.eta = s)) =
-            Scheduler(schedule, opt, update_func)
-    end
-end
 
 end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,0 +1,4 @@
+[deps]
+Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
+InfiniteArrays = "4858937d-0d70-526a-a4dd-2d5cb5dd786c"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
I made an attempt at #52 by adding a Flux extension. 

However, it is not quite working yet. I don't quite know why, so maybe somebody can help. The extension is not correctly loaded, the `Scheduler` struct can't be found, and neither the extension itself. Information on the extension system is a bit short right now as it is still quite new. I am not quite sure what is missing, as I thought that editing the `Project.toml` appropriately should be enough. 

