### PR TITLE
Add initial Optimisers.jl scheduler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
         with:
-          version: '1.6'
+          version: '1'
       - run: |
           julia --project=docs -e '
             using Pkg

--- a/Project.toml
+++ b/Project.toml
@@ -4,13 +4,13 @@ authors = ["Kyle Daruwalla"]
 version = "0.3.7"
 
 [deps]
-Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
 InfiniteArrays = "4858937d-0d70-526a-a4dd-2d5cb5dd786c"
+Optimisers = "3bd65402-5787-11e9-1adc-39752487f4e2"
 
 [compat]
-Flux = "0.11.2, 0.12, 0.13, 0.14"
 InfiniteArrays = "0.10.4, 0.11, 0.12, 0.13"
 julia = "1.6"
+Optimisers = "0.3.1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -9,10 +9,11 @@ Optimisers = "3bd65402-5787-11e9-1adc-39752487f4e2"
 
 [compat]
 InfiniteArrays = "0.10.4, 0.11, 0.12, 0.13"
-julia = "1.6"
 Optimisers = "0.3.1"
+julia = "1.6"
 
 [extras]
+Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [publish]
@@ -21,4 +22,4 @@ theme = "_flux-theme"
 title = "ParameterSchedulers.jl"
 
 [targets]
-test = ["Test"]
+test = ["Flux", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -13,8 +13,8 @@ Optimisers = "0.3.1"
 julia = "1.6"
 
 [extras]
-Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [publish]
 ignore = ["^(gh-pages|juliamnt|julia.dmg)$"]
@@ -22,4 +22,4 @@ theme = "_flux-theme"
 title = "ParameterSchedulers.jl"
 
 [targets]
-test = ["Flux", "Test"]
+test = ["Test", "Zygote"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ParameterSchedulers"
 uuid = "d7d3b36b-41b8-4d0d-a2bf-768c6151755e"
 authors = ["Kyle Daruwalla"]
-version = "0.3.7"
+version = "0.4.0"
 
 [deps]
 InfiniteArrays = "4858937d-0d70-526a-a4dd-2d5cb5dd786c"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ ParameterSchedulers.jl provides common machine learning (ML) schedulers for hype
 using Flux, ParameterSchedulers
 using ParameterSchedulers: Scheduler
 
-opt = Scheduler(Exp(λ = 1e-2, γ = 0.8), Momentum())
+opt = Scheduler(Momentum, Exp(λ = 1e-2, γ = 0.8))
 ```
 
 ## Available Schedules

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
+Optimisers = "3bd65402-5787-11e9-1adc-39752487f4e2"
 ParameterSchedulers = "d7d3b36b-41b8-4d0d-a2bf-768c6151755e"
 Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,3 +1,4 @@
+using Revise
 using Documenter, ParameterSchedulers
 using Markdown
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,4 +1,3 @@
-using Revise
 using Documenter, ParameterSchedulers
 using Markdown
 

--- a/src/ParameterSchedulers.jl
+++ b/src/ParameterSchedulers.jl
@@ -1,8 +1,9 @@
 module ParameterSchedulers
 
 using Base.Iterators
-using Flux
 using InfiniteArrays: OneToInf
+using Optimisers: AbstractRule
+import Optimisers
 
 include("interface.jl")
 
@@ -19,83 +20,7 @@ export Sequence, Loop, Interpolator, Shifted, ComposedSchedule
 
 include("utils.jl")
 
-# TODO
-# Remove this once Optimisers.jl has support
-# for schedules + optimizers
-"""
-    Scheduler{T, O, F}(schedule::AbstractSchedule, opt, update_func)
-    Scheduler(schedule, opt; update_func = (o, s) -> (o.eta = s))
-
-Wrap a `schedule` and `opt` together with a `Scheduler`.
-The `schedule` is iterated on every call to
-[`Flux.apply!`](https://github.com/FluxML/Flux.jl/blob/master/src/optimise/optimisers.jl).
-The `Scheduler` can be used anywhere a Flux optimizer is used.
-
-By default, the learning rate (i.e. `opt.eta`) is scheduled.
-Set `update_func = (opt, schedule_val) -> ...` to schedule an alternate field.
-If `opt` does not have a field `eta`, then there is no default behavior
-(you must manually set `update_func`).
-
-# Arguments
-- `schedule`: the schedule to use
-- `opt`: a Flux optimizer
-- `update_func`: a mutating function of with inputs `(optim, param)`
-                 that mutates `optim`'s fields based on the current `param` value
-
-# Examples
-```julia
-# cosine annealing schedule for Descent
-julia> s = CosAnneal(λ0 = 0.1, λ1 = 0.8, period = 10);
-
-julia> opt = Scheduler(s, Descent())
-Scheduler(CosAnneal{Float64,Int64}(0.1, 0.8, 10), Descent(0.1))
-
-# schedule the momentum term of Momentum
-julia> opt = Scheduler(s, Momentum(); update_func = (o, s) -> o.rho = s)
-Scheduler(CosAnneal{Float64,Int64}(0.1, 0.8, 10), Momentum(0.01, 0.9, IdDict{Any,Any}()))
-```
-"""
-mutable struct Scheduler{T, O, F} <: Flux.Optimise.AbstractOptimiser
-    state::IdDict{Any, Int}
-    schedule::T
-    optim::O
-    update_func::F
-
-    function Scheduler(state::IdDict{Any, Int},
-                       schedule::T,
-                       optim::O,
-                       update_func::F) where {T, O, F}
-        Base.depwarn("""`Scheduler` will transition to explicit Optimisers.jl style
-                        optimizers in the next release""", :Scheduler)
-
-        return new{T, O, F}(state, schedule, optim, update_func)
-    end
-end
-Scheduler(schedule, opt, update_func) =
-    Scheduler(IdDict{Any, Int}(), schedule, opt, update_func)
-
-Base.show(io::IO, s::Scheduler) =
-    print(io, "Scheduler(", s.schedule, ", ", s.optim, ")")
-
-function Flux.Optimise.apply!(opt::Scheduler, x, Δ)
-    # get iteration
-    t = get!(opt.state, x, 1)
-    opt.state[x] = t + 1
-
-    # set param
-    opt.update_func(opt.optim, opt.schedule(t))
-
-    # do normal apply
-    return Flux.Optimise.apply!(opt.optim, x, Δ)
-end
-
-for Opt in (Descent, Momentum, Nesterov, RMSProp,
-            Adam, RAdam, AdaMax, OAdam, AdaGrad,
-            AdaDelta, AMSGrad, NAdam, AdaBelief)
-    @eval begin
-        Scheduler(schedule, opt::$Opt; update_func = (o, s) -> (o.eta = s)) =
-            Scheduler(schedule, opt, update_func)
-    end
-end
+include("scheduler.jl")
+export Scheduler
 
 end

--- a/src/cyclic.jl
+++ b/src/cyclic.jl
@@ -23,13 +23,8 @@ struct Triangle{T, S<:Integer} <: AbstractSchedule{false}
     offset::T
     period::S
 end
-function Triangle(range::T, offset::T, period::S) where {T, S}
-    @warn """Triangle(range0, range1, period) is now Triangle(range, offset, period).
-             To specify by endpoints, use the keyword argument form.
-             This message will be removed in the next version.""" _id=(:tri) maxlog=1
-
+Triangle(range::T, offset::T, period::S) where {T, S} =
     Triangle{T, S}(range, offset, period)
-end
 Triangle(;λ0, λ1, period) = Triangle(abs(λ0 - λ1), min(λ0, λ1), period)
 
 Base.eltype(::Type{<:Triangle{T}}) where T = T
@@ -54,13 +49,7 @@ where `Triangle(t)` is `(2 / π) * abs(asin(sin(π * (t - 1) / schedule.period))
 - `range1`/`λ1`: the second range endpoint
 - `period::Integer`: the period
 """
-function TriangleDecay2(range, offset, period)
-    @warn """TriangleDecay2(range0, range1, period) is now TriangleDecay2(range, offset, period).
-             To specify by endpoints, use the keyword argument form.
-             This message will be removed in the next version.""" _id=(:tri) maxlog=1
-
-    return _tridecay2(range, offset, period)
-end
+TriangleDecay2(range, offset, period) = _tridecay2(range, offset, period)
 TriangleDecay2(;λ0, λ1, period) = _tridecay2(abs(λ0 - λ1), min(λ0, λ1), period)
 
 function _tridecay2(range::T, offset, period) where T
@@ -89,13 +78,7 @@ where `Triangle(t)` is `(2 / π) * abs(asin(sin(π * (t - 1) / schedule.period))
 - `period::Integer`: the period
 - `decay`/`γ`: the decay rate
 """
-function TriangleExp(range, offset, period, γ)
-    @warn """TriangleExp(range0, range1, period, γ) is now TriangleExp(range, offset, period, γ).
-             To specify by endpoints, use the keyword argument form.
-             This message will be removed in the next version.""" _id=(:tri) maxlog=1
-
-    return _triexp(range, offset, period, γ)
-end
+TriangleExp(range, offset, period, γ) = _triexp(range, offset, period, γ)
 TriangleExp(;λ0, λ1, period, γ) = _triexp(abs(λ0 - λ1), min(λ0, λ1), period, γ)
 
 _triexp(range, offset, period, γ) =
@@ -121,13 +104,7 @@ struct Sin{T, S<:Integer} <: AbstractSchedule{false}
     offset::T
     period::S
 end
-function Sin(range::T, offset::T, period::S) where {T, S}
-    @warn """Sin(range0, range1, period) is now Sin(range, offset, period).
-             To specify by endpoints, use the keyword argument form.
-             This message will be removed in the next version.""" _id=(:sine) maxlog=1
-
-    Sin{T, S}(range, offset, period)
-end
+Sin(range::T, offset::T, period::S) where {T, S} = Sin{T, S}(range, offset, period)
 Sin(;λ0, λ1, period) = Sin(abs(λ0 - λ1), min(λ0, λ1), period)
 
 Base.eltype(::Type{<:Sin{T}}) where T = T
@@ -150,13 +127,7 @@ where `Sin(t)` is `abs(sin(π * (t - 1) / period))` (see [`Sin`](@ref)).
 - `offset == min(λ0, λ1)`: the offset / minimum value
 - `period::Integer`: the period
 """
-function SinDecay2(range, offset, period)
-    @warn """SinDecay2(range0, range1, period) is now SinDecay2(range, offset, period).
-             To specify by endpoints, use the keyword argument form.
-             This message will be removed in the next version.""" _id=(:sine) maxlog=1
-
-    return _sindecay2(range, offset, period)
-end
+SinDecay2(range, offset, period) = _sindecay2(range, offset, period)
 SinDecay2(;λ0, λ1, period) = _sindecay2(abs(λ0 - λ1), min(λ0, λ1), period)
 
 function _sindecay2(range::T, offset, period) where T
@@ -182,13 +153,7 @@ where `Sin(t)` is `abs(sin(π * (t - 1) / period))` (see [`Sin`](@ref)).
 - `period::Integer`: the period
 - `γ`: the decay rate
 """
-function SinExp(range, offset, period, γ)
-    @warn """SinExp(range0, range1, period, γ) is now SinExp(range, offset, period, γ).
-             To specify by endpoints, use the keyword argument form.
-             This message will be removed in the next version.""" _id=(:sine) maxlog=1
-
-    return _sinexp(range, offset, period, γ)
-end
+SinExp(range, offset, period, γ) = _sinexp(range, offset, period, γ)
 SinExp(;λ0, λ1, period, γ) = _sinexp(abs(λ0 - λ1), min(λ0, λ1), period, γ)
 
 _sinexp(range, offset, period, γ) =
@@ -231,6 +196,3 @@ function (schedule::CosAnneal)(t)
 
     return schedule.range * (1 + cos(π * t̂ / schedule.period)) / 2 + schedule.offset
 end
-
-Base.@deprecate Cos(range0, range1, period) CosAnneal(λ0 = range0, λ1 = range1, period = period)
-Base.@deprecate Cos(;λ0, λ1, period) CosAnneal(λ0 = λ0, λ1 = λ1, period = period)

--- a/src/scheduler.jl
+++ b/src/scheduler.jl
@@ -1,0 +1,56 @@
+"""
+    Scheduler{T, F} <: Optimiser.AbstractRule
+    Scheduler(constructor, schedules::AbstractSchedule...)
+    Scheduler(constructor; field_a = schedule_a, field_b = schedule_b, ...)
+
+Wrap one or more schedules and optimizer together with a `Scheduler`.
+On each call to [`Optimisers.apply!`](@ref Optimisers.apply!), the schedules
+are iterated and `constructor` is used to invoke an optimization rule with
+updated parameters.
+The `Scheduler` can be used anywhere an Optimisers.jl optimizer is used.
+
+If passed a single schedule and optimizer rule, the scheduler updates the
+learning, `opt.eta`.
+To adjust multiple hyperparameters, pass in multiple schedules as arguments or
+keywords. These will be iterated in order and passed onto to `constructor`
+(i.e. `constructor` should accept the appropriate number of arguments/keywords).
+
+# Arguments
+- `constructor`: a constructor that creates an optimization rule given some
+    parameters (e.g. `Optimisers.AdamW`; note the lack of `()`)
+- `schedules`: the list of optimization rule hyperparameters to schedule as
+    multiple (named) arguments
+
+# Examples
+```julia
+# cosine annealing schedule for Descent
+julia> opt = Scheduler(Descent, CosAnneal(λ0 = 0.1, λ1 = 0.8, period = 10));
+
+# schedule learning rate and momentum of Momentum
+julia> opt = Scheduler(Momentum, CosAnneal(λ0 = 0.1, λ1 = 0.8, period = 10), Exp(0.999, 0.8));
+
+# schedule the weight decay term of AdamW
+julia> opt = Scheduler(AdamW, decay = Exp(1e-3, 0.7));
+```
+"""
+struct Scheduler{T<:Union{<:Tuple, <:NamedTuple}, F} <: AbstractRule
+    constructor::F
+    schedules::T
+end
+Scheduler(constructor, schedules...) = Scheduler(constructor, schedules)
+Scheduler(constructor; schedules...) = Scheduler(constructor, schedules)
+
+_get_opt(scheduler::Scheduler{<:Tuple}, t) =
+    scheduler.constructor((s(t) for s in schedules)...)
+_get_opt(scheduler::Scheduler{<:NamedTuple}, t) =
+    scheduler.constructor(NamedTuple{keys(schedules)}(s(t) for s in schedules)...)
+
+Optimisers.init(o::Scheduler, x::AbstractArray) =
+    (t = 1, opt = Optimisers.init(_get_opt(o, 1), x))
+
+function Optimisers.apply!(o::Scheduler, state, x, dx)
+    opt = _get_opt(o, state.t)
+    new_state, new_dx = Optimisers.apply!(opt, state.opt, x, dx)
+
+    return (t = state.t + 1, opt = new_state), new_dx
+end

--- a/src/scheduler.jl
+++ b/src/scheduler.jl
@@ -4,9 +4,9 @@
     Scheduler(constructor; field_a = schedule_a, field_b = schedule_b, ...)
 
 Wrap one or more schedules and optimizer together with a `Scheduler`.
-On each call to [`Optimisers.apply!`](@ref Optimisers.apply!), the schedules
-are iterated and `constructor` is used to invoke an optimization rule with
-updated parameters.
+On each call to [`Optimisers.apply!`](https://fluxml.ai/Optimisers.jl/dev/api/#Optimisers.apply!),
+the schedules are iterated and `constructor` is used to invoke an
+optimization rule with updated parameters.
 The `Scheduler` can be used anywhere an Optimisers.jl optimizer is used.
 
 If passed a single schedule and optimizer rule, the scheduler updates the

--- a/src/scheduler.jl
+++ b/src/scheduler.jl
@@ -38,12 +38,15 @@ struct Scheduler{T<:Union{<:Tuple, <:NamedTuple}, F} <: AbstractRule
     schedules::T
 end
 Scheduler(constructor, schedules...) = Scheduler(constructor, schedules)
-Scheduler(constructor; schedules...) = Scheduler(constructor, schedules)
+Scheduler(constructor; schedules...) = Scheduler(constructor, (; schedules...))
 
 _get_opt(scheduler::Scheduler{<:Tuple}, t) =
-    scheduler.constructor((s(t) for s in schedules)...)
-_get_opt(scheduler::Scheduler{<:NamedTuple}, t) =
-    scheduler.constructor(NamedTuple{keys(schedules)}(s(t) for s in schedules)...)
+    scheduler.constructor((s(t) for s in scheduler.schedules)...)
+function _get_opt(scheduler::Scheduler{<:NamedTuple}, t)
+    kwargs = NamedTuple{keys(scheduler.schedules)}(s(t) for s in scheduler.schedules)
+
+    return scheduler.constructor(kwargs...)
+end
 
 Optimisers.init(o::Scheduler, x::AbstractArray) =
     (t = 1, opt = Optimisers.init(_get_opt(o, 1), x))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using ParameterSchedulers
-using Flux
+using Zygote
 using Optimisers
 using Test
 
@@ -22,7 +22,7 @@ end
         o = Optimisers.setup(Scheduler(Optimisers.Descent, s), m)
         x = ones(Float32, 3)
         for t in 1:10
-            g = Flux.gradient(m -> sum(m.W * x + m.b), m)[1]
+            g = Zygote.gradient(m -> sum(m.W * x + m.b), m)[1]
             o, m′ = Optimisers.update(o, m, g)
             @test m′.W ≈ m.W - g.W * s(t)
             @test m′.b ≈ m.b - g.b * s(t)
@@ -36,7 +36,7 @@ end
         o = Optimisers.setup(Scheduler(Optimisers.Momentum, eta = seta, rho = srho), m)
         x = ones(Float32, 3)
         for t in 1:10
-            g = Flux.gradient(m -> sum(m.W * x + m.b), m)[1]
+            g = Zygote.gradient(m -> sum(m.W * x + m.b), m)[1]
             o′, m′ = Optimisers.update(o, m, g)
             @test m′.W ≈ m.W - (srho(t) * o.W.state.opt + g.W * seta(t))
             @test m′.b ≈ m.b - (srho(t) * o.b.state.opt + g.b * seta(t))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using ParameterSchedulers
 using Flux
+using Optimisers
 using Test
 
 using InfiniteArrays: OneToInf
@@ -15,17 +16,32 @@ end
     include("complex.jl")
 end
 @testset "Scheduler" begin
-    using ParameterSchedulers: Scheduler
-    m = Chain(Dense(10, 5), Dense(5, 2))
-    ps = Flux.params(m)
-    s = Exp(0.1, 0.5)
-    o = Scheduler(s, Momentum())
-    for t in 1:10
-        g = Flux.gradient(() -> sum(m(rand(Float32, 10, 2))), ps)
-        Flux.update!(o, ps, g)
-        @test o.optim.eta == s(t)
-        for p in ps
-            @test o.state[p] == t + 1
+    @testset "Basic usage" begin
+        m = (W = ones(Float32, 4, 3), b = ones(Float32, 4))
+        s = Exp(0.1, 0.5)
+        o = Flux.setup(Scheduler(Optimisers.Descent, s), m)
+        x = ones(Float32, 3)
+        for t in 1:10
+            g = Flux.gradient(m -> sum(m.W * x + m.b), m)[1]
+            o, m′ = Optimisers.update(o, m, g)
+            @test m′.W ≈ m.W - g.W * s(t)
+            @test m′.b ≈ m.b - g.b * s(t)
+            m = m′
+        end
+    end
+    @testset "Advanced usage" begin
+        m = (W = ones(Float32, 4, 3), b = ones(Float32, 4))
+        seta = Exp(0.1, 0.5)
+        srho = Exp(0.9, 0.9)
+        o = Flux.setup(Scheduler(Optimisers.Momentum, eta = seta, rho = srho), m)
+        x = ones(Float32, 3)
+        for t in 1:10
+            g = Flux.gradient(m -> sum(m.W * x + m.b), m)[1]
+            o′, m′ = Optimisers.update(o, m, g)
+            @test m′.W ≈ m.W - (srho(t) * o.W.state.opt + g.W * seta(t))
+            @test m′.b ≈ m.b - (srho(t) * o.b.state.opt + g.b * seta(t))
+            m = m′
+            o = o′
         end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,7 +19,7 @@ end
     @testset "Basic usage" begin
         m = (W = ones(Float32, 4, 3), b = ones(Float32, 4))
         s = Exp(0.1, 0.5)
-        o = Flux.setup(Scheduler(Optimisers.Descent, s), m)
+        o = Optimisers.setup(Scheduler(Optimisers.Descent, s), m)
         x = ones(Float32, 3)
         for t in 1:10
             g = Flux.gradient(m -> sum(m.W * x + m.b), m)[1]
@@ -33,7 +33,7 @@ end
         m = (W = ones(Float32, 4, 3), b = ones(Float32, 4))
         seta = Exp(0.1, 0.5)
         srho = Exp(0.9, 0.9)
-        o = Flux.setup(Scheduler(Optimisers.Momentum, eta = seta, rho = srho), m)
+        o = Optimisers.setup(Scheduler(Optimisers.Momentum, eta = seta, rho = srho), m)
         x = ones(Float32, 3)
         for t in 1:10
             g = Flux.gradient(m -> sum(m.W * x + m.b), m)[1]


### PR DESCRIPTION
This replaces the old `Scheduler` with an Optimisers.jl friendly scheduler. There is no easy way to support both—the `Scheduler` struct is very different. Accordingly, before merging, we should have a patch release with the dep warning for the old style. This drops Flux as a dependency.

I used the original design for `Scheduler` here instead of using `adjust`. The thought process was to avoid walking the tree multiple times. It allows scheduling multiple hyper-parameters and optionally specifying the field names for the optimization rule.

This PR also removes some old deprecation warnings as part of the breaking release.

Closes #34, closes #52, closes #57.

### PR Checklist

- [x] Tests are added
- [ ] Documentation, if applicable
