### PR TITLE
Add dep warn for `Scheduler` with Flux optimizers

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ParameterSchedulers"
 uuid = "d7d3b36b-41b8-4d0d-a2bf-768c6151755e"
 authors = ["Kyle Daruwalla"]
-version = "0.3.6"
+version = "0.3.7"
 
 [deps]
 Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"

--- a/src/ParameterSchedulers.jl
+++ b/src/ParameterSchedulers.jl
@@ -60,16 +60,15 @@ mutable struct Scheduler{T, O, F} <: Flux.Optimise.AbstractOptimiser
     schedule::T
     optim::O
     update_func::F
+end
+function Scheduler(state::IdDict{Any, Int},
+                   schedule::T,
+                   optim::O,
+                   update_func::F) where {T, O, F}
+    @warn """Scheduler will transition to explicit Optimisers.jl style
+             optimizers in the next release""" _id=(:scheduler) maxlog=1
 
-    function Scheduler{T, O, F}(state::IdDict{Any, Int},
-                                schedule::T,
-                                optim::O,
-                                update_func::F) where {T, O, F}
-        @warn """Scheduler will transition to explicit Optimisers.jl style
-                 optimizers in the next release""" _id=(:scheduler) maxlog=1
-
-        return new{T, O, F}(state, schedule, optim, update_func)
-    end
+    return Scheduler{T, O, F}(state, schedule, optim, update_func)
 end
 Scheduler(schedule, opt, update_func) =
     Scheduler(IdDict{Any, Int}(), schedule, opt, update_func)

--- a/src/ParameterSchedulers.jl
+++ b/src/ParameterSchedulers.jl
@@ -60,15 +60,16 @@ mutable struct Scheduler{T, O, F} <: Flux.Optimise.AbstractOptimiser
     schedule::T
     optim::O
     update_func::F
-end
-function Scheduler(state::IdDict{Any, Int},
-                   schedule::T,
-                   optim::O,
-                   update_func::F) where {T, O, F}
-    @warn """Scheduler will transition to explicit Optimisers.jl style
-             optimizers in the next release""" _id=(:scheduler) maxlog=1
 
-    return Scheduler{T, O, F}(state, schedule, optim, update_func)
+    function Scheduler(state::IdDict{Any, Int},
+                       schedule::T,
+                       optim::O,
+                       update_func::F) where {T, O, F}
+        Base.depwarn("""`Scheduler` will transition to explicit Optimisers.jl style
+                        optimizers in the next release""", :Scheduler)
+
+        return new{T, O, F}(state, schedule, optim, update_func)
+    end
 end
 Scheduler(schedule, opt, update_func) =
     Scheduler(IdDict{Any, Int}(), schedule, opt, update_func)

--- a/src/ParameterSchedulers.jl
+++ b/src/ParameterSchedulers.jl
@@ -60,6 +60,16 @@ mutable struct Scheduler{T, O, F} <: Flux.Optimise.AbstractOptimiser
     schedule::T
     optim::O
     update_func::F
+
+    function Scheduler{T, O, F}(state::IdDict{Any, Int},
+                                schedule::T,
+                                optim::O,
+                                update_func::F) where {T, O, F}
+        @warn """Scheduler will transition to explicit Optimisers.jl style
+                 optimizers in the next release""" _id=(:scheduler) maxlog=1
+
+        return new{T, O, F}(state, schedule, optim, update_func)
+    end
 end
 Scheduler(schedule, opt, update_func) =
     Scheduler(IdDict{Any, Int}(), schedule, opt, update_func)


### PR DESCRIPTION
This adds a deprecation warning that the next breaking release will transition to Optimisers.jl style optimizers.

### PR Checklist

- [x] ~~Tests are added~~
- [x] ~~Documentation, if applicable~~
